### PR TITLE
Modify the logic of Daily Progress By Suites

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ docopt==0.6.2
 python-dateutil==2.6.1
 six==1.10.0
 requests==2.18.4
+yattag==1.9.0

--- a/template/set_template.html
+++ b/template/set_template.html
@@ -35,39 +35,7 @@
             <a href="daily_progress_all.html">
             <div class="footer_left" >
                 <p class="title">Hasal Daily Progress (By Suites)</p>
-                <table class="chart">
-                    <tr>
-                        <th ROWSPAN=2></th>
-                        <th COLSPAN=2>Amazon</th>
-                        <th COLSPAN=2>FaceBook</th>
-                        <th COLSPAN=2>GDoc</th>
-                        <th COLSPAN=2>GMail</th>
-                        <th COLSPAN=2>GSearch</th>
-                        <th COLSPAN=2>YouTube</th>
-                    </tr>
-                    <tr>
-                        <td>Firefox</td>
-                        <td>Chrome</td>
-                        <td>Firefox</td>
-                        <td>Chrome</td>
-                        <td>Firefox</td>
-                        <td>Chrome</td>
-                        <td>Firefox</td>
-                        <td>Chrome</td>
-                        <td>Firefox</td>
-                        <td>Chrome</td>
-                        <td>Firefox</td>
-                        <td>Chrome</td>
-                    </tr>
-					<tr>
-						<td>Windows7</td>
-                        <!--WIN8 TD GO HERE-->
-					</tr>
-					<tr>
-						<td>Windows10</td>
-                        <!--WIN10 TD GO HERE-->
-					</tr>
-                </table>
+                <!-- HASAL DAILY PROGRESS BY SUITES -->
             </div></a>
             <div class="footer_right">
                 <p class="title">Hasal Daily Progress (Overall)</p>


### PR DESCRIPTION
- we should set the status as the worest status of case in the suite
- original logic will only calcuate the amount of `ok` cases, the `pending` and `error` cases will be calcuate as 0.

ex:
- Suite A
  - case A1 `pending[2]`
  - case A2 `pending[4]`
- Suite B
  - case B1 `ok[6]`
  - case B2 `error[0]`
  - case B3 `error[0]`
  - case B4 `error[0]`
- Suite C
  - case C1 `pending[4]`
  - case C2 `error[0]`
  - case C3 `pending[4]`

**original**:
- Suite A: `error` (ok=0)
- Suite B: `pending` (ok=1, but less than cases amount 4)
- Suite C: `error` (ok=0)

**new**:
- Suite A: `pending` (worest status is pending[2])
- Suite B: `error` (worest status is error[0])
- Suite C: `error` (worest status is error[0])